### PR TITLE
tests(#15): filter SIGPIPE lines for trap commands in ubuntu-latest

### DIFF
--- a/failing-tests-re-evaluate/ubuntu-latest/run-varenv
+++ b/failing-tests-re-evaluate/ubuntu-latest/run-varenv
@@ -1,4 +1,0 @@
-echo "warning: some of these tests will fail if arrays have not" >&2
-echo "warning: been compiled into the shell" >&2
-${THIS_SH} ./varenv.tests 2>&1 | grep -v '^expect' > ${BASH_TSTOUT}
-diff ${BASH_TSTOUT} varenv.right && rm -f ${BASH_TSTOUT}

--- a/tests/run-varenv
+++ b/tests/run-varenv
@@ -1,0 +1,7 @@
+echo "warning: some of these tests will fail if arrays have not" >&2
+echo "warning: been compiled into the shell" >&2
+${THIS_SH} ./varenv.tests 2>&1 | grep -v '^expect' > ${BASH_TSTOUT}
+# Filter system-dependent lines
+sed -e '/^trap -- .*SIGPIPE$/d' \
+    "${BASH_TSTOUT}" > "${BASH_TSTOUT}.filtered"
+diff ${BASH_TSTOUT}.filtered varenv.right && rm -f ${BASH_TSTOUT} ${BASH_TSTOUT}.filtered


### PR DESCRIPTION
This is trap related, similar to issues in #14 .